### PR TITLE
reverse override

### DIFF
--- a/macros/dune/source.sql
+++ b/macros/dune/source.sql
@@ -1,6 +1,6 @@
-{% macro ref(model_name) %}
+{% macro source(source_name, table_name) %}
 
-  {% set rel = builtins.ref(model_name) %}
+  {% set rel = builtins.source(source_name, table_name) %}
   {% set newrel = rel.replace_path(database="delta_prod") %}
   {% do return(newrel) %}
 


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Yesterday, I put the catalog override onto the spells/models naming macro (ref). But after debugging more, I realized fewer changes are required if I override the `source` macro which defines where to read raw and decoded tables. 