### PR TITLE
s3 locations for schema and table

### DIFF
--- a/macros/dune/create_schema.sql
+++ b/macros/dune/create_schema.sql
@@ -1,0 +1,12 @@
+{% macro create_schema(relation) -%}
+  {{ adapter.dispatch('create_schema', 'dbt')(relation) }}
+{% endmacro %}
+
+{% macro default__create_schema(relation) -%}
+  {% set s3_bucket = var('DBT_ENV_CUSTOM_ENV_S3_BUCKET', 'trino-dev-datasets-118330671040') %}
+  {% do log('default__create_schema', info=true) %}
+  {%- call statement('create_schema') -%}
+   CREATE SCHEMA {{ relation }} WITH (location = 's3a://{{s3_bucket}}/hive')
+  {% endcall %}
+  {% do log('end', info=true) %}
+{% endmacro %}

--- a/macros/dune/create_schema.sql
+++ b/macros/dune/create_schema.sql
@@ -3,7 +3,7 @@
 {% endmacro %}
 
 {% macro default__create_schema(relation) -%}
-  {% set s3_bucket = var('DBT_ENV_CUSTOM_ENV_S3_BUCKET', 'trino-dev-datasets-118330671040') %}
+  {% set s3_bucket = var('DBT_ENV_CUSTOM_ENV_S3_BUCKET', 'local') %}
   {% do log('default__create_schema', info=true) %}
   {%- call statement('create_schema') -%}
    CREATE SCHEMA {{ relation }} WITH (location = 's3a://{{s3_bucket}}/hive')

--- a/macros/dune/create_table.sql
+++ b/macros/dune/create_table.sql
@@ -2,7 +2,7 @@
 {% macro properties(properties, relation) %}
   {% do log(relation, info=true) %}
 
-  {% set s3_bucket = var('DBT_ENV_CUSTOM_ENV_S3_BUCKET', 'trino-dev-datasets-118330671040') %}
+  {% set s3_bucket = var('DBT_ENV_CUSTOM_ENV_S3_BUCKET', 'local') %}
   {%- if properties is not none -%}
       WITH (
           location = 's3a://{{s3_bucket}}/hive/{{relation.schema}}/{{relation.identifier | replace("__dbt_tmp","")}}'

--- a/macros/dune/create_table.sql
+++ b/macros/dune/create_table.sql
@@ -1,0 +1,29 @@
+
+{% macro properties(properties, relation) %}
+  {% do log(relation, info=true) %}
+
+  {% set s3_bucket = var('DBT_ENV_CUSTOM_ENV_S3_BUCKET', 'trino-dev-datasets-118330671040') %}
+  {%- if properties is not none -%}
+      WITH (
+          location = 's3a://{{s3_bucket}}/hive/{{relation.schema}}/{{relation.identifier | replace("__dbt_tmp","")}}'
+          {%- for key, value in properties.items() -%}
+            {{ key }} = {{ value }}
+            {%- if not loop.last -%}{{ ',\n  ' }}{%- endif -%}
+          {%- endfor -%}
+      )
+  {%- else -%}
+      WITH (
+          location = 's3a://{{s3_bucket}}/hive/{{relation.schema}}/{{relation.identifier | replace("__dbt_tmp","")}}'
+      )
+  {%- endif -%}
+{%- endmacro -%}
+
+
+{% macro trino__create_table_as(temporary, relation, sql) -%}
+  {%- set _properties = config.get('properties') -%}
+  create table {{ relation }}
+    {{ properties(_properties, relation) }}
+  as (
+    {{ sql }}
+  );
+{% endmacro %}


### PR DESCRIPTION
Brief comments on the purpose of your changes:

We need to define the s3 locations for schema and table definitions. We can do that by defining the env var to set an s3 bucket and editing the trino schema and table creation macros. 
